### PR TITLE
Chat model updates

### DIFF
--- a/SharedClasses/ChatSystem.cs
+++ b/SharedClasses/ChatSystem.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace ChatModel
 {
@@ -97,7 +98,7 @@ namespace ChatModel
 			return newConversation; //returns created conversation
 		}
 
-		public Conversation addConversation(string v) //creates a copy of a conversation passed as paramter in serialized form (?)
+		public Conversation addConversation(Stream stream) //creates a copy of a conversation passed as paramter in serialized form (?)
 		{
 			throw new NotImplementedException();
 		}

--- a/SharedClasses/Conversation.cs
+++ b/SharedClasses/Conversation.cs
@@ -53,6 +53,10 @@ namespace ChatModel
 			this.smallestFreeId = 1;
 		}
 
+		public Conversation(ConversationUpdates conv)
+		{
+		}
+
 		public int getId()
 		{
 			return id;
@@ -97,6 +101,11 @@ namespace ChatModel
 				return true;
 			}
 			return false;
+		}
+
+		internal void applyUpdates(ConversationUpdates conv)
+		{
+			throw new NotImplementedException();
 		}
 
 		public Message addMessage(User user, int parentID, MessageContent messageContent1, DateTime datetime)
@@ -156,7 +165,7 @@ namespace ChatModel
 			return null;
 		}
 
-		public Message addMessage(Message m)
+		public Message addMessageUnsafe(Message m)
 		{
 			return messages.TryAdd(m.ID, m) ? m : null;
 		}
@@ -186,18 +195,24 @@ namespace ChatModel
 
 		public ConversationUpdates getUpdates(int lastMessageId)
 		{
-			var updates = new ConversationUpdates(Name, ID);
 			var lastMessageTime = getMessage(lastMessageId)?.getTime();
-			foreach (var message in messages.Values)
-			{
-				if (message.getTime() > lastMessageTime)
-				{
-					updates.addMessage(message);
-				}
-			}
+			return getUpdates(lastMessageTime);
+		}
+
+		public ConversationUpdates getUpdates(DateTime? time)
+		{
+			var updates = new ConversationUpdates(Name, ID);
 
 			updates.Users = getUsers();
 
+			foreach (var message in messages.Values)
+			{
+				if (message.getTime() > time)
+				{
+					updates.addMessageUnsafe(new Message(message));
+				}
+			}
+			updates.converge();
 			return updates;
 		}
 	}

--- a/SharedClasses/Conversation.cs
+++ b/SharedClasses/Conversation.cs
@@ -55,6 +55,21 @@ namespace ChatModel
 
 		public Conversation(ConversationUpdates conv)
 		{
+			this.id = conv.ID;
+			this.name = conv.Name;
+			this.Users = conv.Users;
+			this.messages = conv.getMessagesFull();
+			this.smallestFreeId = 0;
+			foreach (var k in messages.Keys)
+			{
+				smallestFreeId = k > smallestFreeId ? k : smallestFreeId;
+			}
+			smallestFreeId++;
+			foreach (var message in messages.Values)
+			{
+				message.AuthorRef = users.Find(u => u.Reference.Name == message.Author.Name);
+			}
+			converge();
 		}
 
 		public int getId()
@@ -105,7 +120,18 @@ namespace ChatModel
 
 		internal void applyUpdates(ConversationUpdates conv)
 		{
-			throw new NotImplementedException();
+			users.AddRange(conv.getUsersFull());
+			List<int> newMssgIDs = new List<int>();
+			foreach (var mess in conv.getMessages())
+			{
+				addMessageUnsafe(mess);
+				newMssgIDs.Add(mess.ID);
+			}
+			foreach (int id in newMssgIDs)
+			{
+				messages[id].TargetedMessage = messages[id].TargetId == -1 ? null : messages[messages[id].TargetId];
+				messages[id].AuthorRef = users.Find(u => u.Reference.Name == messages[id].Author.Name);
+			}
 		}
 
 		public Message addMessage(User user, int parentID, MessageContent messageContent1, DateTime datetime)
@@ -165,9 +191,34 @@ namespace ChatModel
 			return null;
 		}
 
+		/// <summary>
+		/// Adds a specified message to the conversation.
+		/// </summary>
+		/// <remarks>
+		/// <strong>The specified message will be added despite not matching a valid parent.</strong>
+		/// </remarks>
+		/// <param name="m">Message object to add</param>
+		/// <returns>Message that was added, or <c>null</c>null in case of error.</returns>
 		public Message addMessageUnsafe(Message m)
 		{
-			return messages.TryAdd(m.ID, m) ? m : null;
+			var result = messages.TryAdd(m.ID, m);
+			if (result)
+			{
+				m.AuthorRef = users.Find(u => u.Reference.Name == m.Author.Name);
+			}
+			m.TargetedMessage = messages.GetValueOrDefault(m.TargetId, null);
+			return result ? m : null;
+		}
+
+		/// <summary>
+		/// Fixes the internal structure of messages
+		/// </summary>
+		public void converge()
+		{
+			foreach (Message message in messages.Values)
+			{
+				message.TargetedMessage = messages.GetValueOrDefault(message.TargetId, null);
+			}
 		}
 
 		public bool unmatchWithUser(User user)

--- a/SharedClasses/Conversation.cs
+++ b/SharedClasses/Conversation.cs
@@ -59,7 +59,7 @@ namespace ChatModel
 			this.name = conv.Name;
 			this.Users = conv.Users;
 			this.messages = conv.getMessagesFull();
-			this.smallestFreeId = 0;
+			this.smallestFreeId = 1;
 			foreach (var k in messages.Keys)
 			{
 				smallestFreeId = k > smallestFreeId ? k : smallestFreeId;

--- a/SharedClasses/Conversation.cs
+++ b/SharedClasses/Conversation.cs
@@ -8,7 +8,7 @@ using Util;
 namespace ChatModel
 {
 	[Serializable]
-	public class Conversation
+	public class Conversation : IConversation
 	{
 		private string name;
 		private int id;
@@ -156,6 +156,11 @@ namespace ChatModel
 			return null;
 		}
 
+		public Message addMessage(Message m)
+		{
+			return messages.TryAdd(m.ID, m) ? m : null;
+		}
+
 		public bool unmatchWithUser(User user)
 		{
 			if (Users.Contains(user))
@@ -169,7 +174,7 @@ namespace ChatModel
 			}
 		}
 
-		public MemoryStream serialize()
+		public Stream serialize()
 		{
 			MemoryStream stream = new MemoryStream();
 			var formatter = new BinaryFormatter();
@@ -179,9 +184,21 @@ namespace ChatModel
 			return stream;
 		}
 
-		public Conversation getUpdates(int lastMessageId)
+		public ConversationUpdates getUpdates(int lastMessageId)
 		{
-			throw new NotImplementedException();
+			var updates = new ConversationUpdates(Name, ID);
+			var lastMessageTime = getMessage(lastMessageId)?.getTime();
+			foreach (var message in messages.Values)
+			{
+				if (message.getTime() > lastMessageTime)
+				{
+					updates.addMessage(message);
+				}
+			}
+
+			updates.Users = getUsers();
+
+			return updates;
 		}
 	}
 }

--- a/SharedClasses/ConversationUpdates.cs
+++ b/SharedClasses/ConversationUpdates.cs
@@ -104,7 +104,7 @@ namespace ChatModel
 			{
 				m.AuthorRef = users.Find(u => u.Reference.Name == m.Author.Name);
 			}
-			m.TargetedMessage = messages.GetValueOrDefault(m.TargetId, null);
+			m.setParentUnsafe(messages.GetValueOrDefault(m.TargetId, null));
 			return result ? m : null;
 		}
 
@@ -115,7 +115,7 @@ namespace ChatModel
 		{
 			foreach (Message message in messages.Values)
 			{
-				message.TargetedMessage = messages.GetValueOrDefault(message.TargetId, null);
+				message.setParentUnsafe(messages.GetValueOrDefault(message.TargetId, null));
 			}
 		}
 

--- a/SharedClasses/ConversationUpdates.cs
+++ b/SharedClasses/ConversationUpdates.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChatModel
+{
+	public class ConversationUpdates : IConversation
+	{
+		private string name;
+		private int id;
+		private List<User> users;
+		private Dictionary<int, Message> messages;
+
+		public string Name
+		{
+			get => name;
+			set => name = value;
+		}
+		public int ID => id;
+		public List<User> Users
+		{
+			get => users;
+			set => users = value;
+		}
+
+		public ConversationUpdates(string name, int id)
+		{
+			this.name = name;
+			this.id = id;
+			this.users = new List<User>();
+			this.messages = new Dictionary<int, Message>();
+		}
+
+		public int getId()
+		{
+			return id;
+		}
+
+		public List<User> getUsers()
+		{
+			return users;
+		}
+
+		public string getName()
+		{
+			return name;
+		}
+
+		public ICollection<Message> getMessages()
+		{
+			return messages.Values;
+		}
+
+		public Message getMessage(int id)
+		{
+			if (messages.ContainsKey(id))
+				return messages[id];
+			return null;
+		}
+
+		public Message addMessage(Message m)
+		{
+			return messages.TryAdd(m.ID, m) ? m : null;
+		}
+
+		public Stream serialize()
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/SharedClasses/ConversationUpdates.cs
+++ b/SharedClasses/ConversationUpdates.cs
@@ -61,9 +61,34 @@ namespace ChatModel
 			return null;
 		}
 
-		public Message addMessage(Message m)
+		/// <summary>
+		/// Adds a specified message to the conversation.
+		/// </summary>
+		/// <remarks>
+		/// <strong>The specified message will be added despite not matching a valid parent.</strong>
+		/// </remarks>
+		/// <param name="m">Message object to add</param>
+		/// <returns>Message that was added, or <c>null</c>null in case of error.</returns>
+		public Message addMessageUnsafe(Message m)
 		{
-			return messages.TryAdd(m.ID, m) ? m : null;
+			var result = messages.TryAdd(m.ID, m);
+			if (result)
+			{
+				m.AuthorRef = users.Find(u => u.Name == m.Author.Name);
+			}
+			m.TargetedMessage = messages.GetValueOrDefault(m.TargetId, null);
+			return result ? m : null;
+		}
+
+		/// <summary>
+		/// Fixes the internal structure of messages
+		/// </summary>
+		public void converge()
+		{
+			foreach (Message message in messages.Values)
+			{
+				message.TargetedMessage = messages.GetValueOrDefault(message.TargetId, null);
+			}
 		}
 
 		public Stream serialize()

--- a/SharedClasses/IConversation.cs
+++ b/SharedClasses/IConversation.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.IO;
+
+namespace ChatModel
+{
+	public interface IConversation
+	{
+		string Name { get; set; }
+		int ID { get; }
+		int getId();
+		List<User> getUsers();
+		string getName();
+		ICollection<Message> getMessages();
+		Message getMessage(int id);
+		Message addMessage(Message m);
+		Stream serialize();
+	}
+}

--- a/SharedClasses/IConversation.cs
+++ b/SharedClasses/IConversation.cs
@@ -12,7 +12,7 @@ namespace ChatModel
 		string getName();
 		ICollection<Message> getMessages();
 		Message getMessage(int id);
-		Message addMessage(Message m);
+		Message addMessageUnsafe(Message m);
 		Stream serialize();
 	}
 }

--- a/SharedClasses/Message.cs
+++ b/SharedClasses/Message.cs
@@ -115,7 +115,9 @@ namespace ChatModel
 		{
 			MemoryStream stream = new MemoryStream();
 			var formatter = new BinaryFormatter();
-			formatter.Serialize(stream, this);
+			Message copy = new Message(this);
+			copy.targetedMessage = null;
+			formatter.Serialize(stream, copy);
 			stream.Flush();
 			stream.Position = 0;
 			return stream;

--- a/SharedClasses/Message.cs
+++ b/SharedClasses/Message.cs
@@ -32,6 +32,14 @@ namespace ChatModel
 			}
 		}
 
+		public Refrence<User> AuthorRef
+		{
+			set
+			{
+				authorRef = value;
+			}
+		}
+
 		public Message TargetedMessage
 		{
 			get => targetedMessage;
@@ -61,6 +69,20 @@ namespace ChatModel
 			this.sentTime = datetime;
 			this.id = id;
 			this.TargetedMessage = targeted;
+		}
+
+		/// <summary>
+		/// Constructs new message by doing shallow copy of the object provided
+		/// </summary>
+		/// <param name="other">Template message for construction</param>
+		public Message(Message other)
+		{
+			this.authorRef = other.authorRef;
+			this.author = other.author;
+			this.content = other.content;
+			this.sentTime = other.sentTime;
+			this.id = other.id;
+			this.TargetedMessage = other.TargetedMessage;
 		}
 
 		public Message getParent()

--- a/SharedClasses/Message.cs
+++ b/SharedClasses/Message.cs
@@ -82,12 +82,18 @@ namespace ChatModel
 			this.content = other.content;
 			this.sentTime = other.sentTime;
 			this.id = other.id;
-			this.TargetedMessage = other.TargetedMessage;
+			this.targetId = other.targetId;
+			this.targetedMessage = other.targetedMessage;
 		}
 
 		public Message getParent()
 		{
 			return targetedMessage;
+		}
+
+		public void setParentUnsafe(Message t)
+		{
+			targetedMessage = t;
 		}
 
 		public int getId()

--- a/SharedClasses/ServerChatSystem.cs
+++ b/SharedClasses/ServerChatSystem.cs
@@ -8,9 +8,15 @@ namespace ChatModel
 
 		public ServerChatSystem() : base() { } //no-arg constructor calling ChatSystem constructor
 
-		public User getUpdatesToUser(string v, DateTime t)
+		public UserUpdates getUpdatesToUser(string userName, DateTime t)
 		{
-			throw new NotImplementedException();
+			var user = users.Find(u => u.Name == userName);
+			var updates = new UserUpdates();
+			foreach (var conv in user.getConversations())
+			{
+				updates.addConversation(conv.getUpdates(t));
+			}
+			return updates;
 		}
 
 		public List<Conversation> getConversationsOfUser(string userName) //method to return a list of all conversations of user with user name

--- a/SharedClasses/UserUpdates.cs
+++ b/SharedClasses/UserUpdates.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ChatModel
+{
+	public class UserUpdates : IEnumerable<ConversationUpdates>
+	{
+		private List<ConversationUpdates> conversations;
+
+		public UserUpdates()
+		{
+			this.conversations = new List<ConversationUpdates>();
+		}
+		public UserUpdates(ConversationUpdates[] conversations)
+		{
+			this.conversations = conversations.ToList<ConversationUpdates>();
+		}
+		public void addConversation(ConversationUpdates conversation)
+		{
+			this.conversations.Add(conversation);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return ((IEnumerable)conversations).GetEnumerator();
+		}
+
+		public IEnumerator<ConversationUpdates> GetEnumerator()
+		{
+			return ((IEnumerable<ConversationUpdates>)conversations).GetEnumerator();
+		}
+	}
+}

--- a/chatAppTest/ClientChatSystemTest.cs
+++ b/chatAppTest/ClientChatSystemTest.cs
@@ -22,17 +22,23 @@ namespace chatAppTest
 		[TestMethod]
 		public void applyUpdatesTest()
 		{
+			// Creating 'server' chat system
 			ServerChatSystem chatSystem = new ServerChatSystem();
+			// Creating two users
 			User user1 = chatSystem.addNewUser("Jaú Kowalski");
 			User user2 = chatSystem.addNewUser("Kasia èdüb≥o");
+			// Creating a conversation with those users
 			Conversation savedConversation = chatSystem.addConversation("Konfa 1", user1, user2);
+			// Sending a message
 			MessageContent msgContent1 = new TextContent("Heeejoooo");
 			DateTime datetime = DateTime.Now;
 			Message sentMessage1 = chatSystem.sendMessage(savedConversation.getId(), "Jaú Kowalski", -1, msgContent1, datetime);
-
+			// Creating client chat system
 			ClientChatSystem clientChatSystem = new ClientChatSystem();
 			clientChatSystem.addNewUser("Kasia èdüb≥o");
+			// Applying updates
 			clientChatSystem.applyUpdates(chatSystem.getUpdatesToUser("Kasia èdüb≥o", datetime - TimeSpan.FromSeconds(3)));
+			// Checks
 			bool conversationPresent = false;
 			foreach (var conversation in clientChatSystem.getUser("Kasia èdüb≥o").getConversations())
 			{

--- a/chatAppTest/ConversationTest.cs
+++ b/chatAppTest/ConversationTest.cs
@@ -307,19 +307,33 @@ namespace chatAppTest
 		[TestMethod]
 		public void getUpdatesTest()
 		{
+			// Conversation
 			Conversation conversation1 = new Conversation("Konfa 1", 1);
+
+			// Users
 			User user1 = new User("Mr. X");
 			User user2 = new User("Ms. Y");
+			// Matching
+			conversation1.matchWithUser(user1);
+			conversation1.matchWithUser(user2);
+			user1.matchWithConversation(conversation1);
+			user2.matchWithConversation(conversation1);
+
+			// Messages
+			//  Content
 			MessageContent msgContent1 = new TextContent("Heeejoooo");
 			MessageContent msgContent2 = new TextContent("No czeœæ");
 			MessageContent msgContent3 = new TextContent("Co tam s³ychaæ?");
+			//  Timestamps
 			DateTime datetime = DateTime.Now;
 			DateTime datetime2 = datetime + TimeSpan.FromSeconds(5);
 			DateTime datetime3 = datetime + TimeSpan.FromSeconds(19);
+			//  Sending
 			Message sentMessage1 = conversation1.addMessage(user1, -1, msgContent1, datetime);
 			Message sentMessage2 = conversation1.addMessage(user2, 1, msgContent2, datetime2);
 			Message sentMessage3 = conversation1.addMessage(user1, 2, msgContent3, datetime3);
 
+			// Checks
 			bool hasMessage2 = false;
 			bool hasMessage3 = false;
 			bool hasWrongMessage = false;

--- a/chatAppTest/ConversationTest.cs
+++ b/chatAppTest/ConversationTest.cs
@@ -343,7 +343,7 @@ namespace chatAppTest
 				{
 					hasMessage2 = true;
 					Assert.IsTrue(message.getUser().getName() == sentMessage2.getUser().getName());
-					Assert.IsTrue(message.getParent().getId() == 1);
+					Assert.IsTrue(message.TargetId == 1);
 					Assert.IsTrue(message.getContent().getData() == sentMessage2.getContent().getData());
 					Assert.IsTrue(message.getTime() == sentMessage2.getTime());
 				}

--- a/chatAppTest/ServerChatSystemTest.cs
+++ b/chatAppTest/ServerChatSystemTest.cs
@@ -21,10 +21,10 @@ namespace chatAppTest
 			DateTime datetime = DateTime.Now;
 			Message sentMessage1 = chatSystem.sendMessage(savedConversation.getId(), "Jaú Kowalski", -1, msgContent1, datetime);
 			Message sentMessage2 = chatSystem.sendMessage(savedConversation2.getId(), "Jaú Kowalski", -1, msgContent2, datetime);
-			User updates = chatSystem.getUpdatesToUser("Kasia èdüb≥o", datetime - TimeSpan.FromSeconds(3));
+			UserUpdates updates = chatSystem.getUpdatesToUser("Kasia èdüb≥o", datetime - TimeSpan.FromSeconds(3));
 			bool containsConversation = false;
 			bool containsWrongConversation = false;
-			foreach (var conversation in updates.getConversations())
+			foreach (var conversation in updates)
 			{
 				if (conversation.getId() == savedConversation.getId() && conversation.getName() == savedConversation.getName())
 				{


### PR DESCRIPTION
Implemented extraction of Timestamp based updates to Conversation and User classes. These should cut of the amount of data sent through the network upon updating.
The `IConversation` interface was a good idea, but I think we should replace it with a base class, since both `Conversation` and `ConversationUpdates` have very similar implementations of nearly all methods. For user updates we don't need that, as this class has a slightly different character (as discussed earlier).
The positive thing is, that all test should pass from now on.
Please don't merge yet, but opinion and code review is very welcome.